### PR TITLE
fix typo in to_onnx.py

### DIFF
--- a/converters/to_onnx.py
+++ b/converters/to_onnx.py
@@ -98,10 +98,18 @@ def main() -> None:
         required=True,
     )
 
+    arg(
+        "-i",
+        "--image_path",
+        type=int,
+        help="The path of the input image",
+        required=True,
+    )
+
     arg("-o", "--output_file", type=str, help="Path to save onnx model.", required=True)
     args = parser.parse_args()
 
-    raw_image = cv2.imread("tests/data/13.jpg")
+    raw_image = cv2.imread(args.image_path)
 
     image = prepare_image(raw_image, args.max_size)
 
@@ -145,7 +153,7 @@ def main() -> None:
             }
         ]
 
-    im = albu.Compose([albu.LongestMaxSize(max_size=1280)])(image=raw_image)["image"]
+    im = albu.Compose([albu.LongestMaxSize(max_size=args.max_size)])(image=raw_image)["image"]
     cv2.imwrite("example.jpg", vis_annotations(im, annotations))
 
 


### PR DESCRIPTION
Add size to the last part of the code, otherwise the max_sizes wont be the same resulting in weird boxes positions:
<img width="640" alt="Screenshot 2022-07-20 at 16 53 50" src="https://user-images.githubusercontent.com/28659618/180013779-25868741-bc50-4d02-ae08-17b836ce73bb.png">


